### PR TITLE
forgot to check param type when generate @bind variable

### DIFF
--- a/lib/DBIx/Custom.pm
+++ b/lib/DBIx/Custom.pm
@@ -434,7 +434,10 @@ sub execute {
       }
       else {
         for my $param (@$params) {
-          $affected = $sth->execute(map { $param->{$_} } @{$query->{columns}});
+          $affected = $sth->execute(map { ref $param->{$_} eq 'ARRAY' ?
+              grep {ref $_ ne 'DBIx::Custom::NotExists'} @{$param->{$_}} :
+              $param->{$_}
+          } @{$query->{columns}});
         }
       }
     };


### PR DESCRIPTION
Reproduce
---

when I use mysql db with async result, and where param is array,
result is wrong.

``` perl
use AnyEvent;

my $cond = AnyEvent->condvar;

# dbi is mysql db

$dbi->select(
    'key1',
    table        => 'table1',
    prepare_attr => {async => 1},
    where        => {key1 => [1, 2, 3]},
    async        => sub {
        my ($dbi, $ret) = @_;
        # `$ret->all` return empty
        # even it has values in mysql db
    }
);

$cond->recv;
```

Now I fixed it in `lib/DBIx/Custom.pm`, add ref check when generate bind values